### PR TITLE
Implementation of calculation of invariants and energies

### DIFF
--- a/CuSuperHelium/CuSuperHelium/CuSuperHelium.vcxproj
+++ b/CuSuperHelium/CuSuperHelium/CuSuperHelium.vcxproj
@@ -106,6 +106,7 @@
     <ClInclude Include="createM.cuh" />
     <ClInclude Include="cuDoubleComplexOperators.cuh" />
     <ClInclude Include="Derivatives.cuh" />
+    <ClInclude Include="Energies.cuh" />
     <ClInclude Include="MatrixSolver.cuh" />
     <ClInclude Include="ProblemProperties.hpp" />
     <ClInclude Include="AutonomousRungeKuttaStepper.cuh" />

--- a/CuSuperHelium/CuSuperHelium/CuSuperHelium.vcxproj.filters
+++ b/CuSuperHelium/CuSuperHelium/CuSuperHelium.vcxproj.filters
@@ -24,5 +24,6 @@
     <ClInclude Include="SimpleEuler.cuh" />
     <ClInclude Include="cuDoubleComplexOperators.cuh" />
     <ClInclude Include="AutonomousProblem.h" />
+    <ClInclude Include="Energies.cuh" />
   </ItemGroup>
 </Project>

--- a/CuSuperHelium/CuSuperHelium/Energies.cuh
+++ b/CuSuperHelium/CuSuperHelium/Energies.cuh
@@ -1,0 +1,180 @@
+#pragma once
+#include "ProblemProperties.hpp"
+#include "cuda_runtime.h"
+#include "device_launch_parameters.h"
+#include <cub/cub.cuh>
+#include "constants.cuh"
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+
+template <int N>
+class EnergyBase
+{
+public:
+	EnergyBase(ProblemProperties& properties);
+	virtual ~EnergyBase();
+	double getEnergy() const;
+protected:
+	ProblemProperties& properties;
+	double* devEnergy;
+
+	void* tempStorage = nullptr; // Temporary storage for CUB operations
+	size_t tempStorageBytes = 0;
+
+	virtual double scaleEnergy(double energy) const = 0; // Pure virtual function to scale energy
+};
+
+template <int N>
+class KineticEnergy : public EnergyBase<N>
+{
+public:
+	using EnergyBase<N>::EnergyBase; // Inherit constructor from EnergyBase
+	void CalculateEnergy(std_complex* devPhi, std_complex* devZ, std_complex* devZp, std_complex* velocitiesLower);
+	virtual double scaleEnergy(double energy) const override
+	{
+		return energy * 0.25 / PI_d;
+	}
+};
+
+template <int N>
+class GravitationalEnergy : public EnergyBase<N>
+{
+public:
+	using EnergyBase<N>::EnergyBase; // Inherit constructor from EnergyBase
+	void CalculateEnergy(std_complex* devZ, std_complex* devZp);
+	virtual double scaleEnergy(double energy) const override
+	{
+		return energy * 0.25 * (1.0 + this->properties.rho) / PI_d;
+	}
+};
+
+template <int N>
+class SurfaceEnergy : public EnergyBase<N>
+{
+public:
+	using EnergyBase<N>::EnergyBase; // Inherit constructor from EnergyBase
+	void CalculateEnergy(std_complex* devZp);
+	virtual double scaleEnergy(double energy) const override
+	{
+		return (energy - 2.0 * PI_d) * this->properties.kappa / (2.0 * PI_d);
+	}
+};
+
+
+struct KineticEnergyCombination
+{
+	const std_complex* Z;
+	const std_complex* Phi;
+	const std_complex* Zp;
+	const std_complex* velocitiesLower;
+	const std_complex* velocitiesUpper;
+	const ProblemProperties properties;
+
+	__host__ __device__ KineticEnergyCombination(const std_complex* z, const std_complex* phi, const std_complex* zp, const std_complex* velocitiesLower, const std_complex* velocitiesUpper, const ProblemProperties properties)
+		: Z(z), Phi(phi), Zp(zp), velocitiesLower(velocitiesLower), velocitiesUpper(velocitiesUpper), properties(properties) {
+	}
+
+	__device__ double operator()(int k) const
+	{
+		return (Phi[k].real() + 0.5 * properties.U * (1.0 + properties.rho) * Z[k].real()) * (-1.0 * Zp[k].imag() * velocitiesLower[k].real() + Zp[k].real() * velocitiesLower[k].imag()) \
+			- 0.5 * properties.U * ((velocitiesLower[k].real() + properties.rho * velocitiesUpper[k].real()) * Zp[k].real() + (velocitiesLower[k].imag() + properties.rho * velocitiesUpper[k].imag()) * Zp[k].imag() \
+				+ 0.5 * properties.U * (1.0 - properties.rho) * Zp[k].real()) * Z[k].imag();
+	}
+};
+
+struct GravitationalEnergyCombination
+{
+	const std_complex* Z;
+	const std_complex* Zp;
+	__host__ __device__ GravitationalEnergyCombination(const std_complex* z, const std_complex* zp)
+		: Z(z), Zp(zp) {
+	}
+	__device__ double operator()(int k) const
+	{
+		return Z[k].imag() * Z[k].imag() * Zp[k].real();
+	}
+};
+
+struct SurfaceEnergyCombination
+{
+	const std_complex* Zp;
+	__host__ __device__ SurfaceEnergyCombination(const std_complex* zp)
+		: Zp(zp) {}
+	__device__ double operator()(int k) const
+	{
+		return sqrt(Zp[k].real() * Zp[k].real() + Zp[k].imag() * Zp[k].imag());
+	}
+};
+
+template <int N>
+EnergyBase<N>::EnergyBase(ProblemProperties& properties) : properties(properties)
+{
+	cudaMalloc(&devEnergy, sizeof(double));
+}
+
+template <int N>
+EnergyBase<N>::~EnergyBase()
+{
+	cudaFree(devEnergy);
+}
+
+template <int N>
+double EnergyBase<N>::getEnergy() const
+{
+	cudaDeviceSynchronize();
+	double e;
+	cudaMemcpy(&e, devEnergy, sizeof(double), cudaMemcpyDeviceToHost);
+	return this->scaleEnergy(e);
+}
+
+template<int N>
+void KineticEnergy<N>::CalculateEnergy(std_complex* devPhi, std_complex* devZ, std_complex* devZp, std_complex* velocitiesLower)
+{
+	thrust::counting_iterator<int> countingIterator(0);
+
+	// create a transform iterator that applies the KineticEnergyCombination functor
+	KineticEnergyCombination kineticEnergyCombination(devZ, devPhi, devZp, velocitiesLower, velocitiesLower, this->properties);
+
+	auto transformIterator = thrust::make_transform_iterator(countingIterator, kineticEnergyCombination);
+
+	// get temporary storage size
+	cub::DeviceReduce::Sum(this->tempStorage, this->tempStorageBytes, transformIterator, this->devEnergy, N);
+
+	// allocate temporary storage
+	cudaMalloc(&this->tempStorage, this->tempStorageBytes);
+
+	// perform the reduction
+	cub::DeviceReduce::Sum(this->tempStorage, this->tempStorageBytes, transformIterator, this->devEnergy, N);
+}
+
+
+
+template<int N>
+void GravitationalEnergy<N>::CalculateEnergy(std_complex* devZ, std_complex* devZp)
+{
+	thrust::counting_iterator<int> countingIterator(0);
+	// create a transform iterator that applies the GravitationalEnergyCombination functor
+	GravitationalEnergyCombination gravitationalEnergyCombination(devZ, devZp);
+	auto transformIterator = thrust::make_transform_iterator(countingIterator, gravitationalEnergyCombination);
+	// get temporary storage size
+	cub::DeviceReduce::Sum(this->tempStorage, this->tempStorageBytes, transformIterator, this->devEnergy, N);
+	// allocate temporary storage
+	cudaMalloc(&this->tempStorage, this->tempStorageBytes);
+	// perform the reduction
+	cub::DeviceReduce::Sum(this->tempStorage, this->tempStorageBytes, transformIterator, this->devEnergy, N);
+}
+
+template<int N>
+void SurfaceEnergy<N>::CalculateEnergy(std_complex* devZp)
+{
+	thrust::counting_iterator<int> countingIterator(0);
+	// create a transform iterator that applies the SurfaceEnergyCombination functor
+	SurfaceEnergyCombination surfaceEnergyCombination(devZp);
+	auto transformIterator = thrust::make_transform_iterator(countingIterator, surfaceEnergyCombination);
+	// get temporary storage size
+	cub::DeviceReduce::Sum(this->tempStorage, this->tempStorageBytes, transformIterator, this->devEnergy, N);
+	// allocate temporary storage
+	cudaMalloc(&this->tempStorage, this->tempStorageBytes);
+	// perform the reduction
+	cub::DeviceReduce::Sum(this->tempStorage, this->tempStorageBytes, transformIterator, this->devEnergy, N);
+}

--- a/CuSuperHelium/CuSuperHelium/WaterBoundaryIntegralCalculator.cuh
+++ b/CuSuperHelium/CuSuperHelium/WaterBoundaryIntegralCalculator.cuh
@@ -29,6 +29,7 @@ public:
 	KineticEnergy<N> kineticEnergy; ///< Kinetic energy calculator for the water boundary integral problem
 	GravitationalEnergy<N> gravitationalEnergy; ///< Gravitational energy calculator for the water boundary integral problem
 	SurfaceEnergy<N> surfaceEnergy; ///< Surface energy calculator for the water boundary integral problem
+	VolumeFlux<N> volumeFlux; ///< Volume flux calculator for the water boundary integral problem
 
 	/// <summary>
 	/// Initializes the time step manager by copying the host data to the device memory for the initial conditions. Use this only once when setting up the problem from the host side.
@@ -88,7 +89,9 @@ private:
 };
 
 template<int N>
-WaterBoundaryIntegralCalculator<N>::WaterBoundaryIntegralCalculator(ProblemProperties& problemProperties) : AutonomousProblem<cufftDoubleComplex, 2*N>(), problemProperties(problemProperties), kineticEnergy(problemProperties), gravitationalEnergy(problemProperties), surfaceEnergy(problemProperties),  zPhiDerivative(problemProperties), 
+WaterBoundaryIntegralCalculator<N>::WaterBoundaryIntegralCalculator(ProblemProperties& problemProperties) : AutonomousProblem<cufftDoubleComplex, 2*N>(), problemProperties(problemProperties),
+kineticEnergy(problemProperties), gravitationalEnergy(problemProperties), surfaceEnergy(problemProperties), volumeFlux(problemProperties),
+	zPhiDerivative(problemProperties), 
 matrix_threads(16, 16), matrix_blocks((N + 15) / 16, (N + 15) / 16)
 {
 	// Allocate device memory for the various arrays used in the water boundary integral calculation
@@ -281,6 +284,7 @@ inline void WaterBoundaryIntegralCalculator<N>::runTimeStep()
 	kineticEnergy.CalculateEnergy(devPhi, devZ, devZp, devVelocitiesLower); // Calculate the kinetic energy based on the current state
 	gravitationalEnergy.CalculateEnergy(devZ, devZp); // Calculate the gravitational energy based on the current state
 	surfaceEnergy.CalculateEnergy(devZp); // Calculate the surface energy based on the current state
+	volumeFlux.CalculateEnergy(devZp, devVelocitiesLower); // Calculate the volume flux based on the current state
 }
 template<int N>
 void WaterBoundaryIntegralCalculator<N>::run(std_complex* initialState)

--- a/CuSuperHelium/CuSuperHelium/kernel.cu
+++ b/CuSuperHelium/CuSuperHelium/kernel.cu
@@ -93,6 +93,7 @@ int runTimeStep()
 	std::vector<double> PE(steps, 0);
 	std::vector<double> SurfaceEnergy(steps, 0);
 	std::vector<double> TotalEnergy(steps, 0);
+	std::vector<double> VolumeFlux(steps, 0);
 
 	x0.resize(N, 0);
 	y0.resize(N, 0);
@@ -155,6 +156,7 @@ int runTimeStep()
         KE[i] = timeStepManager.kineticEnergy.getEnergy();
 		PE[i] = timeStepManager.gravitationalEnergy.getEnergy();
 		SurfaceEnergy[i] = timeStepManager.surfaceEnergy.getEnergy();
+		VolumeFlux[i] = timeStepManager.volumeFlux.getEnergy();
 
 		TotalEnergy[i] = KE[i] + PE[i] + SurfaceEnergy[i];
 	}
@@ -207,6 +209,14 @@ int runTimeStep()
 	plt::legend();
 	plt::xlabel("Time Steps");
 	plt::ylabel("Energy");
+
+	plt::figure();
+	plt::title("Volume Flux");
+	plt::plot(VolumeFlux, { {"label", "Volume Flux"} });
+	plt::xlabel("Time Steps");
+	plt::ylabel("Volume Flux");
+	plt::legend();
+
     plt::show();
     
 

--- a/CuSuperHelium/CuSuperHelium/kernel.cu
+++ b/CuSuperHelium/CuSuperHelium/kernel.cu
@@ -88,6 +88,11 @@ int runTimeStep()
 
     std::vector<double> x;
 	std::vector<double> y;
+	
+    std::vector<double> KE(steps, 0);
+	std::vector<double> PE(steps, 0);
+	std::vector<double> SurfaceEnergy(steps, 0);
+	std::vector<double> TotalEnergy(steps, 0);
 
 	x0.resize(N, 0);
 	y0.resize(N, 0);
@@ -147,6 +152,11 @@ int runTimeStep()
 	for (int i = 0; i < steps; i++) {
         // Perform a time step
         rungeKunta.runStep();
+        KE[i] = timeStepManager.kineticEnergy.getEnergy();
+		PE[i] = timeStepManager.gravitationalEnergy.getEnergy();
+		SurfaceEnergy[i] = timeStepManager.surfaceEnergy.getEnergy();
+
+		TotalEnergy[i] = KE[i] + PE[i] + SurfaceEnergy[i];
 	}
 	
 
@@ -186,6 +196,17 @@ int runTimeStep()
 	plt::plot(x0, y0, {{"label", "Initial Position"}});
     plt::plot(x, y);
     plt::legend();
+
+    plt::figure();
+	plt::title("Kinetic, Potential and Surface Energy");
+	plt::plot(KE, { {"label", "Kinetic Energy"} });
+	plt::plot(PE, { {"label", "Potential Energy"} });
+	plt::plot(SurfaceEnergy, { {"label", "Surface Energy"} });
+	plt::plot(TotalEnergy, { {"label", "Total Energy"} });
+
+	plt::legend();
+	plt::xlabel("Time Steps");
+	plt::ylabel("Energy");
     plt::show();
     
 


### PR DESCRIPTION
This pull request introduces a new energy calculation framework for the `CuSuperHelium` module, enabling the computation of kinetic, gravitational, surface, and volume flux energies. It integrates these calculations into the water boundary integral problem and visualizes the results. The most important changes include the addition of the `Energies.cuh` file, modifications to the `WaterBoundaryIntegralCalculator` class, and updates to the `kernel.cu` file for energy tracking and plotting.

### Energy Calculation classes:

* **Addition of `Energies.cuh`**: Introduced a new header file defining the `EnergyBase` class and its derived classes (`KineticEnergy`, `GravitationalEnergy`, `SurfaceEnergy`, and `VolumeFlux`). These classes encapsulate energy calculations using CUDA and Thrust libraries.

### Integration with Water Boundary Integral Problem:

* **Updates to `WaterBoundaryIntegralCalculator.cuh`**:
  - Added member variables for energy calculators (`kineticEnergy`, `gravitationalEnergy`, `surfaceEnergy`, `volumeFlux`) and initialized them in the constructor. [[1]](diffhunk://#diff-747bf1148d111bc72cba9fc356120ee4b16b4c49896ac34e6f66f8d5577c3052R29-R33) [[2]](diffhunk://#diff-747bf1148d111bc72cba9fc356120ee4b16b4c49896ac34e6f66f8d5577c3052L85-R94)
  - Integrated energy calculations into the `runTimeStep()` method to compute energies at each time step.

### Visualization and Tracking:

* **Updates to `kernel.cu`**:
  - Added vectors to track energy values (`KE`, `PE`, `SurfaceEnergy`, `TotalEnergy`) and volume flux over time steps.
  - Modified the time-stepping loop to compute and store energy values and total energy at each step.
  - Added plots to visualize kinetic, potential, surface, and total energies, as well as volume flux, over time steps.

### Supporting Changes:

* **Project File Updates**:
  - Included `Energies.cuh` in the project configuration files (`CuSuperHelium.vcxproj` and `CuSuperHelium.vcxproj.filters`). [[1]](diffhunk://#diff-2f40f1d1be358f95c84b1f0dc9acc598d65d2b97f901b31dfe8be878341f6da1R109) [[2]](diffhunk://#diff-9864562ce959bec91a5db397ea7023fab33d06b0035bdd54a64d64f1473d0045R27)